### PR TITLE
add SMTPPort setting to pass address port

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -49,7 +49,9 @@ func (m *SMTPEmailBackend) Init(conf map[string]string) error {
 	if err != nil {
 		return err
 	}
-
+	if port == "" {
+		port = conf["SMTPPort"]
+	}
 	m.host = host
 	m.port, _ = strconv.Atoi(port)
 	m.user = user


### PR DESCRIPTION
For environment setting we cant provide address:port because : is a special character  it makes sense to have  SMTPPort  for address port.

Note this is optional so nothing is broken. But I need this to be merged so I can vendor it to fix  #1270 
	